### PR TITLE
fix: Tune js-dos audio settings to reduce crackling

### DIFF
--- a/src/dos/create-dos.ts
+++ b/src/dos/create-dos.ts
@@ -12,7 +12,8 @@ export async function createDos(
     window
       .Dos(canvas, {
         wdosboxUrl: "/static/js-dos/wdosbox.js",
-      })
+        SDL_numSimultaneouslyQueuedBuffers: 10,
+      } as Record<string, unknown>)
       .ready((fs, main) => resolve({ fs, main }));
   });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,24 @@ export default defineConfig({
           dest: "static/js-dos",
         },
         {
+          src: "node_modules/js-dos/dist/wdosbox.js",
+          dest: "static/js-dos",
+          transform: (content) =>
+            content.replace(
+              "bufferingDelay=50/1e3",
+              "bufferingDelay=200/1e3",
+            ),
+        },
+        {
+          src: "node_modules/js-dos/dist/js-dos.js",
+          dest: "static/js-dos",
+          transform: (content) =>
+            content
+              .replace("blocksize=1024", "blocksize=4096")
+              .replace("prebuffer=20", "prebuffer=100")
+              .replace("pcspeaker=true", "pcspeaker=false"),
+        },
+        {
           src: "game/*",
           dest: "static/game",
         },


### PR DESCRIPTION
- Add SDL_numSimultaneouslyQueuedBuffers option and patch wdosbox/js-dos buffering params at build time
- Increase blocksize, prebuffer, and bufferingDelay; disable PC speaker